### PR TITLE
Fixed nginx query string errors

### DIFF
--- a/src/experiments/hosting/digitalocean/README.md
+++ b/src/experiments/hosting/digitalocean/README.md
@@ -95,7 +95,7 @@ server {
     index index.html index.htm index.php;
 
     location / {
-        try_files $uri /index.php;
+        try_files $uri /index.php?$query_string;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
Updated experiment to add $query_string to ```try``` block. This enables nginx to process params attached to the URI.